### PR TITLE
:sparkles: Replace breakpoint with CSS-based element

### DIFF
--- a/src/application.less
+++ b/src/application.less
@@ -154,20 +154,15 @@ div[data-lang="bc0"] .cm-editor {
     border-radius: .3rem !important;
 }
 
-.cm-gutters { margin: 1px; }
+// .cm-gutters { margin: 1px; }
 .cm-scroller { overflow: auto; }
 .cm-editor { border: 1px solid silver; border-radius: 0 0 0.3rem 0.3rem; }
 .ͼ1.cm-editor.cm-focused { border: 1px solid #52a3f970; outline: none; }
 .cm-execLine-light { background-color: #ffff00;  }
 .cm-execLine-dark { background-color: #505000;  }
-.cm-lineNumbers > .cm-gutterElement { padding: 0 !important; }
 .cm-foldPlaceholder { padding: 0 0.5rem; color: black; background: #EEEEEE; border: none; }
-.cm-breakpoint-gutter {
-    cursor: pointer;
-}
-.cm-breakpoint-gutter:hover {
-    background-color: #E7E7E7;
-}
+.cm-breakpoint-gutter:hover { background-color: #E7E7E7; }
+.editor-breakpoint{ margin-top: 2px; height: 14px; width: 14px; background-color: #ff001a; border-radius: 50%; display: inline-block; }
 
 .active-href {
     color: @primary-color;

--- a/src/components/bc0-editor.tsx
+++ b/src/components/bc0-editor.tsx
@@ -39,7 +39,7 @@ export default class BC0Editor extends React.Component<BC0EditorProps>
                         language.of(BC0Language),
                         execLineHighlighter(this.props.execLine, globalThis.UI_EDITOR_THEME),
                     ]}
-                    editable={true}
+                    editable={false}
                 />
     }
 }

--- a/src/components/c0-editor.tsx
+++ b/src/components/c0-editor.tsx
@@ -58,12 +58,12 @@ export default class C0Editor extends React.Component<C0EditorProps>
                         }
                         value = {this.props.editorValue}
                         extensions={[
+                            breakpoint_extension,
                             LoadDocumentPlugin(".c0", this.props.updateName),
                             basicSetup(),
                             indentUnit.of("    "),
                             execLineHighlighter(this.props.execLine, globalThis.UI_EDITOR_THEME),
                             C0(),
-                            breakpoint_extension,
                         ]}
                         editable={this.props.editable}
                     />

--- a/src/components/editor_extension/breakpoint_marker.ts
+++ b/src/components/editor_extension/breakpoint_marker.ts
@@ -68,7 +68,11 @@ function toggleBreakpoint(
 
 const breakpointMarker = new (class extends GutterMarker {
   toDOM() {
-    return document.createTextNode("🔴");
+    const span_node = document.createElement("span");
+    span_node.setAttribute("class", "editor-breakpoint");
+    span_node.innerText = " ";
+    return span_node;
+    // return document.createTextNode("🔴");
   }
 })();
 
@@ -92,10 +96,10 @@ const breakpointGutter: BreakpointExt = (props) => {
 
     EditorView.baseTheme({
       ".cm-breakpoint-gutter .cm-gutterElement": {
-        paddingLeft: "1px",
-        paddingTop: "1.5px",
+        paddingLeft: "0px",
+        paddingTop: "0px",
         cursor: "pointer",
-        fontSize: "0.6rem",
+        fontSize: "14px",
       },
     }),
   ];


### PR DESCRIPTION
Replace the 🔴 emoji used in breakpoint gutter with the css-based red dot so that the behavior (appearance) is identical across all platforms.

<img width="483" alt="image" src="https://user-images.githubusercontent.com/47029019/209880736-d7077bef-2014-470f-a4ed-093954862451.png">
