### PR TITLE
9 struct fields dont appear until assignment

### DIFF
--- a/src/application.tsx
+++ b/src/application.tsx
@@ -26,7 +26,6 @@ export default class C0VMApplication extends React.Component<
             
             BC0SourceCode: "",
             BC0BreakPoints: new Set(),
-            TypedefRecord: new Map(),
 
             C0Editors: [{ title: "Untitled_0.c0", key: 0, content: "", breakpoints: [] }],
             ActiveEditor: 0,
@@ -68,7 +67,6 @@ export default class C0VMApplication extends React.Component<
                 state={this.state.C0Runtime}
                 c0_only={this.state.c0_only}
                 isFullScreen={this.state.dbgFullScreen}
-                typedef={this.state.TypedefRecord}
                 setFullScreen={(s) => this.setState({dbgFullScreen: s})}
             />
         ) : null;

--- a/src/application.tsx
+++ b/src/application.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from "react";
+import React from "react";
 import "./application.less";
 import "./embeddable.less";
 
@@ -28,7 +28,7 @@ export default class C0VMApplication extends React.Component<
             BC0BreakPoints: new Set(),
             TypedefRecord: new Map(),
 
-            C0Editors: [{ title: "Untitled_0.c0", key: 0, content: "", breakpoints: [], innerRef: createRef()}],
+            C0Editors: [{ title: "Untitled_0.c0", key: 0, content: "", breakpoints: [] }],
             ActiveEditor: 0,
 
             PrintoutValue: "",

--- a/src/application.tsx
+++ b/src/application.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createRef } from "react";
 import "./application.less";
 import "./embeddable.less";
 
@@ -28,7 +28,7 @@ export default class C0VMApplication extends React.Component<
             BC0BreakPoints: new Set(),
             TypedefRecord: new Map(),
 
-            C0Editors: [{ title: "Untitled_0.c0", key: 0, content: "", breakpoints: []}],
+            C0Editors: [{ title: "Untitled_0.c0", key: 0, content: "", breakpoints: [], innerRef: createRef()}],
             ActiveEditor: 0,
 
             PrintoutValue: "",

--- a/src/components/c0-editor-group.tsx
+++ b/src/components/c0-editor-group.tsx
@@ -128,7 +128,6 @@ export default class C0EditorGroup extends React.Component <C0EditorGroupProps>
                                 updateName    = {(name) => this.set_tab_name(editor.key, name)}
                                 setBreakPts   = {(bps)  => this.set_brkpt_for_editor(editor.key, bps)}
                                 editable      = {this.props.currLine === undefined}
-                                innerRef      = {editor.innerRef}
                             />
                         </TabPane>;
                     }

--- a/src/components/c0-editor-group.tsx
+++ b/src/components/c0-editor-group.tsx
@@ -124,7 +124,6 @@ export default class C0EditorGroup extends React.Component <C0EditorGroupProps>
                                 editorValue   = {editor.content}
                                 breakPoints   = {editor.breakpoints}
                                 updateContent = {(s) => this.props.updateContent(editor.key, s)}
-                                updateTypedef = {(newTypeDef) => this.props.updateTypedef(editor.key, newTypeDef)}
                                 updateName    = {(name) => this.set_tab_name(editor.key, name)}
                                 setBreakPts   = {(bps)  => this.set_brkpt_for_editor(editor.key, bps)}
                                 editable      = {this.props.currLine === undefined}

--- a/src/components/c0-editor-group.tsx
+++ b/src/components/c0-editor-group.tsx
@@ -123,11 +123,12 @@ export default class C0EditorGroup extends React.Component <C0EditorGroupProps>
                                 execLine      = {lineNumber}
                                 editorValue   = {editor.content}
                                 breakPoints   = {editor.breakpoints}
-                                updateContent = {(s: string) => this.props.updateContent(editor.key, s)}
-                                updateTypedef = {(nt: Map<string, string>) => this.props.updateTypedef(editor.key, nt)}
-                                updateName    = {(s: string) => this.set_tab_name(editor.key, s)}
-                                setBreakPts   = {(lns) => this.set_brkpt_for_editor(editor.key, lns)}
+                                updateContent = {(s) => this.props.updateContent(editor.key, s)}
+                                updateTypedef = {(newTypeDef) => this.props.updateTypedef(editor.key, newTypeDef)}
+                                updateName    = {(name) => this.set_tab_name(editor.key, name)}
+                                setBreakPts   = {(bps)  => this.set_brkpt_for_editor(editor.key, bps)}
                                 editable      = {this.props.currLine === undefined}
+                                innerRef      = {editor.innerRef}
                             />
                         </TabPane>;
                     }

--- a/src/components/c0-editor.tsx
+++ b/src/components/c0-editor.tsx
@@ -66,7 +66,6 @@ export default class C0Editor extends React.Component<C0EditorProps>
                             C0(),
                         ]}
                         editable={this.props.editable}
-                        ref     ={this.props.innerRef}
                     />
                 </div>;
     }

--- a/src/components/c0-editor.tsx
+++ b/src/components/c0-editor.tsx
@@ -66,6 +66,7 @@ export default class C0Editor extends React.Component<C0EditorProps>
                             C0(),
                         ]}
                         editable={this.props.editable}
+                        ref     ={this.props.innerRef}
                     />
                 </div>;
     }

--- a/src/components/c0-editor.tsx
+++ b/src/components/c0-editor.tsx
@@ -4,27 +4,9 @@ import ReactCodeMirror, { basicSetup } from "@uiw/react-codemirror";
 import LoadDocumentPlugin from "./editor_extension/blank_load";
 import { C0 } from "./editor_extension/syntax/c0";
 
-import { indentUnit, syntaxTree } from "@codemirror/language";
-import { EditorState } from "@codemirror/state";
+import { indentUnit } from "@codemirror/language";
 import execLineHighlighter from "./editor_extension/exec_position";
 import breakpointGutter from "./editor_extension/breakpoint_marker";
-
-
-function typedefResolver(s: EditorState): Map<string, string> {
-    const tree = syntaxTree(s);
-    const map = new Map<string, string>();
-    for (let ptr = tree.cursor(); ptr.next() !== false; ) {
-        if (ptr.type.is("TypeDefinition")) {
-            ptr.firstChild();       // ptr = typedef keyword itself
-            ptr.nextSibling();      // ptr = Source Type
-            const source_type = s.sliceDoc(ptr.from, ptr.to);
-            ptr.nextSibling();      // ptr = Target Type
-            const alias_type = s.sliceDoc(ptr.from, ptr.to);
-            map.set(alias_type, source_type);
-        }
-    }
-    return map;
-}
 
 export default class C0Editor extends React.Component<C0EditorProps>
 {
@@ -52,7 +34,6 @@ export default class C0Editor extends React.Component<C0EditorProps>
                             {
                                 if (v.docChanged) {
                                     this.props.updateContent(v.state.doc.toString());
-                                    this.props.updateTypedef(typedefResolver(v.state));
                                 }
                             }
                         }

--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -6,24 +6,6 @@ import { Segmented } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCode } from "@fortawesome/free-solid-svg-icons";
 
-function merge_typedef(original: Map<string, TypeDefInfo>, editor_key: number, newSet: Map<string, string>): Map<string, TypeDefInfo> {
-    const newTypedef = new Map<string, TypeDefInfo>();
-    original.forEach(
-        (value, key) => {
-            if (value.key !== editor_key) {
-                newTypedef.set(key, value);
-            }
-        }
-    )
-    newSet.forEach(
-        (value, key) => {
-            newTypedef.set(key, {source: value, key: editor_key});
-        }
-    );
-    return newTypedef;
-}
-
-
 export default class CodeEditor extends React.Component
 <CodeEditorProps, CodeEditorState>
 {
@@ -80,9 +62,6 @@ export default class CodeEditor extends React.Component
                     newPanel        = {() => this.create_panel()}
                     removePanel     = {(key) => this.remove_panel(key)}
                     updateContent   = {(key, s) => this.update_content(key, s)}
-                    updateTypedef   = {(key, newMap) => {
-                        this.props.set_app_state({TypedefRecord: merge_typedef(this.props.app_state.TypedefRecord, key, newMap)})
-                    }}
                 />
             </div>);
     }
@@ -97,9 +76,6 @@ export default class CodeEditor extends React.Component
                 newPanel        = {() => this.create_panel()}
                 removePanel     = {(key) => this.remove_panel(key)}
                 updateContent   = {(key, s) => this.update_content(key, s)}
-                updateTypedef   = {(key, newMap) => {
-                    this.props.set_app_state({TypedefRecord: merge_typedef(this.props.app_state.TypedefRecord, key, newMap)})
-                }}
             />;
         } else {
             const vm = this.props.app_state.C0Runtime;

--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createRef } from "react";
 import BC0Editor from "./bc0-editor";
 import C0EditorGroup from "./c0-editor-group";
 
@@ -43,7 +43,8 @@ export default class CodeEditor extends React.Component
             title: `Untitled_${this.state.C0_nextKey}.c0`,
             key: this.state.C0_nextKey,
             content: "",
-            breakpoints: []
+            breakpoints: [],
+            innerRef: createRef()
         });
         this.props.set_app_state({C0Editors: new_editors, ActiveEditor: this.state.C0_nextKey});
         this.setState({C0_nextKey: this.state.C0_nextKey + 1})
@@ -59,7 +60,9 @@ export default class CodeEditor extends React.Component
 
     update_content(key: number, s: string) {
         let ns: C0EditorTab[] = [...this.props.app_state.C0Editors];
-        ns = ns.map((tab) => tab.key === key ? {key: tab.key, title: tab.title, content: s, breakpoints: tab.breakpoints} : tab);
+        ns = ns.map((tab) => tab.key === key ? {
+                key: tab.key, title: tab.title, content: s, breakpoints: tab.breakpoints, innerRef: tab.innerRef
+            } : tab);
         this.props.set_app_state({C0Editors: ns, contentChanged: true});
     }
 

--- a/src/components/code-editor.tsx
+++ b/src/components/code-editor.tsx
@@ -1,11 +1,10 @@
-import React, { createRef } from "react";
+import React from "react";
 import BC0Editor from "./bc0-editor";
 import C0EditorGroup from "./c0-editor-group";
 
 import { Segmented } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCode } from "@fortawesome/free-solid-svg-icons";
-import C0VM_RuntimeState from "../vm_core/exec/state";
 
 function merge_typedef(original: Map<string, TypeDefInfo>, editor_key: number, newSet: Map<string, string>): Map<string, TypeDefInfo> {
     const newTypedef = new Map<string, TypeDefInfo>();
@@ -44,7 +43,6 @@ export default class CodeEditor extends React.Component
             key: this.state.C0_nextKey,
             content: "",
             breakpoints: [],
-            innerRef: createRef()
         });
         this.props.set_app_state({C0Editors: new_editors, ActiveEditor: this.state.C0_nextKey});
         this.setState({C0_nextKey: this.state.C0_nextKey + 1})
@@ -61,7 +59,7 @@ export default class CodeEditor extends React.Component
     update_content(key: number, s: string) {
         let ns: C0EditorTab[] = [...this.props.app_state.C0Editors];
         ns = ns.map((tab) => tab.key === key ? {
-                key: tab.key, title: tab.title, content: s, breakpoints: tab.breakpoints, innerRef: tab.innerRef
+                key: tab.key, title: tab.title, content: s, breakpoints: tab.breakpoints
             } : tab);
         this.props.set_app_state({C0Editors: ns, contentChanged: true});
     }
@@ -76,7 +74,7 @@ export default class CodeEditor extends React.Component
                     </h3>
                 </div>
                 <C0EditorGroup
-                    currLine        = {(this.props.app_state.C0Runtime as (C0VM_RuntimeState | undefined))?.state.CurrC0RefLine}
+                    currLine        = {this.props.app_state.C0Runtime?.state.CurrC0RefLine}
                     appState        = {this.props.app_state}
                     set_app_state   = {(ns) => this.props.set_app_state(ns)}
                     newPanel        = {() => this.create_panel()}
@@ -93,7 +91,7 @@ export default class CodeEditor extends React.Component
         let content = undefined;
         if (this.state.mode === "c0") {
             content = <C0EditorGroup
-                currLine        = {(this.props.app_state.C0Runtime as (C0VM_RuntimeState | undefined))?.state.CurrC0RefLine}
+                currLine        = {this.props.app_state.C0Runtime?.state.CurrC0RefLine}
                 appState        = {this.props.app_state}
                 set_app_state   = {(ns) => this.props.set_app_state(ns)}
                 newPanel        = {() => this.create_panel()}
@@ -104,7 +102,7 @@ export default class CodeEditor extends React.Component
                 }}
             />;
         } else {
-            const vm: C0VM_RuntimeState | undefined = this.props.app_state.C0Runtime;
+            const vm = this.props.app_state.C0Runtime;
             content = <BC0Editor
                 updateContent={s => this.props.set_app_state({BC0SourceCode: s})}
                 editorValue  ={this.props.app_state.BC0SourceCode}

--- a/src/components/debug_console/debug_console.tsx
+++ b/src/components/debug_console/debug_console.tsx
@@ -38,14 +38,14 @@ export default class DebugConsole extends React.Component
         )
     }
 
-    resolve_render_view(): React.ReactNode {
+    resolve_render_view(typedef: Map<string, string>): React.ReactNode {
         if (this.state.show === false) return null;
         const S = this.props.state;
         if (S === undefined) return this.render_no_valid_state();
         switch (this.state.mode) {
-            case "Table": return <TabularDebugEvaluation   state={S.state} mem={S.allocator} cnt={S.step_cnt} typedef={this.props.typedef}/>;
-            case "Graph": return <GraphicalDebugEvaluation state={S.state} mem={S.allocator} cnt={S.step_cnt} typedef={this.props.typedef}/>;
-            case "Detail": return <DetailDebugEvaluation   state={S.state} mem={S.allocator} cnt={S.step_cnt} typedef={this.props.typedef}/>;
+            case "Table": return <TabularDebugEvaluation   state={S.state} mem={S.allocator} cnt={S.step_cnt} typedef={typedef}/>;
+            case "Graph": return <GraphicalDebugEvaluation state={S.state} mem={S.allocator} cnt={S.step_cnt} typedef={typedef}/>;
+            case "Detail": return <DetailDebugEvaluation   state={S.state} mem={S.allocator} cnt={S.step_cnt} typedef={typedef}/>;
         }
     }
 
@@ -95,6 +95,7 @@ export default class DebugConsole extends React.Component
         ><FontAwesomeIcon icon={faDownLeftAndUpRightToCenter}/></button>
 
         const full_screen_btn = (this.props.isFullScreen) ? exit_full_screen : toggle_full_screen;
+
         const selector_option = this.props.c0_only ?  
                                     [{
                                         label: "Table", value: "Table",
@@ -113,15 +114,15 @@ export default class DebugConsole extends React.Component
                                         label: "Detail", value: "Detail",
                                         icon: <FontAwesomeIcon icon={faTable} />
                                     }];
+        
+        const typedef = this.props.state?.typedef ?? new Map();
+        const revTypedef = new Map<string, string>();
+        typedef.forEach((source, alias) => {revTypedef.set(source, alias)});
+        
         return (
-            <div
-                id="c0vm-debug-console"
-                className={ this.state.show ? "debug-console-box" : "" }
-            >
+            <div id="c0vm-debug-console" className={ this.state.show ? "debug-console-box" : "" }>
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
-                    <h3
-                        onClick={() => this.setState((state) => { return { show: !state.show } })}
-                    >
+                    <h3 onClick={() => this.setState((state) => { return { show: !state.show } })}>
                         <FontAwesomeIcon icon={faBug} />
                         {" Debug Console "}
                         {this.state.show ? <FontAwesomeIcon icon={faAngleDown} /> : <FontAwesomeIcon icon={faAngleRight} />}
@@ -139,7 +140,7 @@ export default class DebugConsole extends React.Component
                             : null
                     }
                 </div>
-                {this.resolve_render_view()}
+                {this.resolve_render_view(revTypedef)}
             </div>
         )
     }

--- a/src/components/debug_console/debug_console.tsx
+++ b/src/components/debug_console/debug_console.tsx
@@ -10,8 +10,6 @@ import { faAngleDown, faAngleRight, faList, faCodeMerge, faBug, faUpRightAndDown
 
 import { Result, Segmented } from "antd";
 
-import C0VM_RuntimeState from "../../vm_core/exec/state";
-
 import TabularDebugEvaluation from "./tabular_debugger";
 import GraphicalDebugEvaluation from "./graphical_debugger";
 import DetailDebugEvaluation from "./detail_debugger";
@@ -42,7 +40,7 @@ export default class DebugConsole extends React.Component
 
     resolve_render_view(): React.ReactNode {
         if (this.state.show === false) return null;
-        const S = this.props.state as C0VM_RuntimeState;
+        const S = this.props.state;
         if (S === undefined) return this.render_no_valid_state();
         switch (this.state.mode) {
             case "Table": return <TabularDebugEvaluation   state={S.state} mem={S.allocator} cnt={S.step_cnt} typedef={this.props.typedef}/>;

--- a/src/components/debug_console/debug_console.tsx
+++ b/src/components/debug_console/debug_console.tsx
@@ -116,8 +116,8 @@ export default class DebugConsole extends React.Component
                                     }];
         
         const typedef = this.props.state?.typedef ?? new Map();
-        const revTypedef = new Map<string, string>();
-        typedef.forEach((source, alias) => {revTypedef.set(source, alias)});
+        // const revTypedef = new Map<string, string>();
+        // typedef.forEach((source, alias) => {revTypedef.set(source, alias)});
         
         return (
             <div id="c0vm-debug-console" className={ this.state.show ? "debug-console-box" : "" }>
@@ -140,7 +140,7 @@ export default class DebugConsole extends React.Component
                             : null
                     }
                 </div>
-                {this.resolve_render_view(revTypedef)}
+                {this.resolve_render_view(typedef)}
             </div>
         )
     }

--- a/src/components/debug_console/detail_component/detail_stackframe.tsx
+++ b/src/components/debug_console/detail_component/detail_stackframe.tsx
@@ -42,15 +42,15 @@ export default class DetailStackFrame extends React.Component<
         for (let i = this.props.frame.S.length - 1; i >= 0; i --) {
             const to_be_rendered = this.props.frame.S[i];
             stack_info.push(
-                <p key={i + "-stack-name"}>{i} - <code>{Type2String(to_be_rendered.type, this.props.typedefRec)}</code></p>
+                <p key={i + "-stack-name"}>{i} - <code>{Type2String(to_be_rendered.type, this.props.typedef)}</code></p>
             );
             stack_info.push(
                 <C0ValueStackDisplay
                     key={i + "-value"}
                     value={to_be_rendered}
                     mem={this.props.mem}
+                    typedef={this.props.typedef}
                     typeRecord={this.props.typeRecord}
-                    typedefRec={this.props.typedefRec}
                     default_expand={true}
                 />
             );
@@ -66,15 +66,15 @@ export default class DetailStackFrame extends React.Component<
                 );
             } else{
                 var_info.push(
-                    <p key={i + "-var-name"}>{i} - <code>{Type2String(to_be_rendered.type, this.props.typedefRec)} {this.props.frame.P.varName[i]}</code></p>
+                    <p key={i + "-var-name"}>{i} - <code>{Type2String(to_be_rendered.type, this.props.typedef)} {this.props.frame.P.varName[i]}</code></p>
                 );
                 var_info.push(
                     <C0ValueTabularDisplay
                         key={i + "-value"}
                         value={to_be_rendered}
                         mem={this.props.mem}
+                        typedef={this.props.typedef}
                         typeRecord={this.props.typeRecord}
-                        typedefRec={this.props.typedefRec}
                         default_expand={true}
                     />
                 );

--- a/src/components/debug_console/detail_debugger.tsx
+++ b/src/components/debug_console/detail_debugger.tsx
@@ -13,7 +13,7 @@ export default class DetailDebugEvaluation extends React.Component<
                     frame={this.props.state.CallStack[i]}
                     mem={this.props.mem}
                     typeRecord={this.props.state.TypeRecord}
-                    typedefRec={this.props.typedef}
+                    typedef={this.props.typedef}
                     key={i}
                 />
             );
@@ -23,7 +23,7 @@ export default class DetailDebugEvaluation extends React.Component<
                 frame={this.props.state.CurrFrame}
                 mem={this.props.mem}
                 typeRecord={this.props.state.TypeRecord}
-                typedefRec={this.props.typedef}
+                typedef={this.props.typedef}
                 key={this.props.state.CallStack.length}
             />
         )

--- a/src/components/debug_console/tabular_component/tabular_c0value.tsx
+++ b/src/components/debug_console/tabular_component/tabular_c0value.tsx
@@ -57,7 +57,7 @@ export default class C0ValueTabularDisplay extends React.Component<
                         mem={this.props.mem}
                         value={vals[i]}
                         typeRecord={this.props.typeRecord}
-                        typedefRec={this.props.typedefRec}
+                        typedef={this.props.typedef}
                         default_expand={false}
                     />
                 </li>
@@ -129,7 +129,7 @@ export default class C0ValueTabularDisplay extends React.Component<
                             mem={this.props.mem}
                             value={{ type: value_to_render.type.value, value: this.props.value.value }}
                             typeRecord={this.props.typeRecord}
-                            typedefRec={this.props.typedefRec}
+                            typedef={this.props.typedef}
                             default_expand={false}
                         />
                         )
@@ -155,8 +155,8 @@ export default class C0ValueTabularDisplay extends React.Component<
                             <C0ValueTabularDisplay
                                 mem={this.props.mem}
                                 value={deref_value}
+                                typedef={this.props.typedef}
                                 typeRecord={this.props.typeRecord}
-                                typedefRec={this.props.typedefRec}
                                 default_expand={false}
                             />
                         </li>
@@ -211,8 +211,8 @@ export default class C0ValueTabularDisplay extends React.Component<
                             <C0ValueTabularDisplay
                                 value={entry.value}
                                 mem={this.props.mem}
+                                typedef={this.props.typedef}
                                 typeRecord={this.props.typeRecord}
-                                typedefRec={this.props.typedefRec}
                                 default_expand={false}
                             />
                         </div>

--- a/src/components/debug_console/tabular_component/tabular_stackframe.tsx
+++ b/src/components/debug_console/tabular_component/tabular_stackframe.tsx
@@ -30,15 +30,15 @@ export default class TabularStackFrame extends React.Component<
             const to_be_rendered = this.props.frame.V[i];
             if (to_be_rendered === undefined) continue;
             var_info.push(
-                <p key={i + "-name"}><code>{Type2String(to_be_rendered.type, this.props.typedefRec)} {this.props.frame.P.varName[i]}</code></p>
+                <p key={i + "-name"}><code>{Type2String(to_be_rendered.type, this.props.typedef)} {this.props.frame.P.varName[i]}</code></p>
             )
             var_info.push(
                 <C0ValueTabularDisplay
                     key={i + "-value"}
                     value={to_be_rendered}
                     mem={this.props.mem}
+                    typedef={this.props.typedef}
                     typeRecord={this.props.typeRecord}
-                    typedefRec={this.props.typedefRec}
                     default_expand={true}
                 />
             )

--- a/src/components/debug_console/tabular_debugger.tsx
+++ b/src/components/debug_console/tabular_debugger.tsx
@@ -13,8 +13,8 @@ export default class TabularDebugEvaluation extends React.Component<
                 <TabularStackFrame
                     frame={this.props.state.CallStack[i]}
                     mem={this.props.mem}
+                    typedef={this.props.typedef}
                     typeRecord={this.props.state.TypeRecord}
-                    typedefRec={this.props.typedef}
                     key={i}
                 />
             );
@@ -23,8 +23,8 @@ export default class TabularDebugEvaluation extends React.Component<
             <TabularStackFrame
                 frame={this.props.state.CurrFrame}
                 mem={this.props.mem}
+                typedef={this.props.typedef}
                 typeRecord={this.props.state.TypeRecord}
-                typedefRec={this.props.typedef}
                 key={this.props.state.CallStack.length}
             />
         )

--- a/src/components/main-control-bar.tsx
+++ b/src/components/main-control-bar.tsx
@@ -6,7 +6,8 @@ import * as VM from "../vm_core/vm_interface";
 import remote_compile from "../network/remote_compile";
 
 import tsLogo from "../assets/ts-logo-128.svg";
-import { extract_typedef } from "../network/c0_parser";
+import { extract_all_typedef } from "../network/c0_parser";
+
 
 /**
  * Use AbortRef() to allow us interrupt current VM execution outside
@@ -42,9 +43,11 @@ export default function MainControlBar(props: MainControlProps) {
             return;
         }
 
+        const typedefs = extract_all_typedef(appState.C0Editors);
         let new_runtime, can_continue = undefined;
+
         if (appState.C0Runtime === undefined) {
-            const init_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, appState.TypedefRecord, print_update, MEM_POOL_SIZE);
+            const init_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, typedefs, print_update, MEM_POOL_SIZE);
             if (init_state === undefined) return;
             [new_runtime, can_continue] = await VM.step(init_state, appState.c0_only, print_update);
         } else {
@@ -64,10 +67,12 @@ export default function MainControlBar(props: MainControlProps) {
             return;
         }
 
+        const typedefs = extract_all_typedef(appState.C0Editors);
         let init_state = undefined;
         let new_runtime, can_continue = undefined;
+
         if (appState.C0Runtime === undefined) {
-            init_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, appState.TypedefRecord, print_update, MEM_POOL_SIZE);
+            init_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, typedefs, print_update, MEM_POOL_SIZE);
             if (init_state === undefined) return;
         } else {
             init_state = appState.C0Runtime;
@@ -114,7 +119,8 @@ export default function MainControlBar(props: MainControlProps) {
 
     const restart_c0runtime = async () => {
         clear_print();
-        const new_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, appState.TypedefRecord, print_update, globalThis.MEM_POOL_SIZE);
+        const typedefs = extract_all_typedef(appState.C0Editors);
+        const new_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, typedefs, print_update, globalThis.MEM_POOL_SIZE);
         props.set_app_state({C0Runtime: new_state});
     };
 
@@ -132,9 +138,9 @@ export default function MainControlBar(props: MainControlProps) {
         );
     };
 
-    const test_fn = () => {
-        extract_typedef("typedef struct node node_t;\n typedef struct ll_head ll_head_t;\n int main() { return 0; }");
-    }
+    // const test_fn = () => {
+    //     // extract_typedef("typedef struct node node_t;\n typedef struct ll_head ll_head_t;\n int main() { return 0; }");
+    // }
 
     // UI Buttons
     const CompileButton = 
@@ -178,14 +184,14 @@ export default function MainControlBar(props: MainControlProps) {
             <FontAwesomeIcon icon={faUndo} className="hide-in-mobile"/>{" Restart "}
         </button>;
     
-    const DevTestButton = 
-        <button
-            className="base-btn danger-btn unselectable"
-            id="ctr-btn-restart"
-            onClick={test_fn}
-        >
-            <FontAwesomeIcon icon={faCode} className="hide-in-mobile"/>{" Dev Test "}
-        </button>;
+    // const DevTestButton = 
+    //     <button
+    //         className="base-btn danger-btn unselectable"
+    //         id="ctr-btn-restart"
+    //         onClick={test_fn}
+    //     >
+    //         <FontAwesomeIcon icon={faCode} className="hide-in-mobile"/>{" Dev Test "}
+    //     </button>;
 
     return (
         <div className="main-control">
@@ -193,7 +199,6 @@ export default function MainControlBar(props: MainControlProps) {
                 <h3 className="unselectable">C0VM.<img src={tsLogo} style={{display: "inline-block", height: "1rem", marginBottom: "0.4rem"}} alt="ts"/></h3>
             </a>
             <div className="control-btn-group">
-                {DevTestButton}
                 {CompileButton}
                 {StepButton}
                 {RunButton}

--- a/src/components/main-control-bar.tsx
+++ b/src/components/main-control-bar.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { faBoltLightning, faPlay, faScrewdriverWrench, faStepForward, faUndo } from "@fortawesome/free-solid-svg-icons";
+import { faBoltLightning, faCode, faPlay, faScrewdriverWrench, faStepForward, faUndo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import * as VM from "../vm_core/vm_interface";
 import remote_compile from "../network/remote_compile";
 
 import tsLogo from "../assets/ts-logo-128.svg";
+import { extract_typedef } from "../network/c0_parser";
 
 /**
  * Use AbortRef() to allow us interrupt current VM execution outside
@@ -131,6 +132,10 @@ export default function MainControlBar(props: MainControlProps) {
         );
     };
 
+    const test_fn = () => {
+        extract_typedef("typedef struct node node_t;\n typedef struct ll_head ll_head_t;\n int main() { return 0; }");
+    }
+
     // UI Buttons
     const CompileButton = 
         <button
@@ -172,6 +177,15 @@ export default function MainControlBar(props: MainControlProps) {
         >
             <FontAwesomeIcon icon={faUndo} className="hide-in-mobile"/>{" Restart "}
         </button>;
+    
+    const DevTestButton = 
+        <button
+            className="base-btn danger-btn unselectable"
+            id="ctr-btn-restart"
+            onClick={test_fn}
+        >
+            <FontAwesomeIcon icon={faCode} className="hide-in-mobile"/>{" Dev Test "}
+        </button>;
 
     return (
         <div className="main-control">
@@ -179,6 +193,7 @@ export default function MainControlBar(props: MainControlProps) {
                 <h3 className="unselectable">C0VM.<img src={tsLogo} style={{display: "inline-block", height: "1rem", marginBottom: "0.4rem"}} alt="ts"/></h3>
             </a>
             <div className="control-btn-group">
+                {DevTestButton}
                 {CompileButton}
                 {StepButton}
                 {RunButton}

--- a/src/components/main-control-bar.tsx
+++ b/src/components/main-control-bar.tsx
@@ -1,12 +1,11 @@
 import React from "react";
-import { faBoltLightning, faCode, faPlay, faScrewdriverWrench, faStepForward, faUndo } from "@fortawesome/free-solid-svg-icons";
+import { faBoltLightning, faPlay, faScrewdriverWrench, faStepForward, faUndo } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import * as VM from "../vm_core/vm_interface";
 import remote_compile from "../network/remote_compile";
 
 import tsLogo from "../assets/ts-logo-128.svg";
-import { extract_all_typedef } from "../network/c0_parser";
 
 
 /**
@@ -43,11 +42,10 @@ export default function MainControlBar(props: MainControlProps) {
             return;
         }
 
-        const typedefs = extract_all_typedef(appState.C0Editors);
         let new_runtime, can_continue = undefined;
 
         if (appState.C0Runtime === undefined) {
-            const init_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, typedefs, print_update, MEM_POOL_SIZE);
+            const init_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, print_update, MEM_POOL_SIZE);
             if (init_state === undefined) return;
             [new_runtime, can_continue] = await VM.step(init_state, appState.c0_only, print_update);
         } else {
@@ -67,12 +65,11 @@ export default function MainControlBar(props: MainControlProps) {
             return;
         }
 
-        const typedefs = extract_all_typedef(appState.C0Editors);
         let init_state = undefined;
         let new_runtime, can_continue = undefined;
 
         if (appState.C0Runtime === undefined) {
-            init_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, typedefs, print_update, MEM_POOL_SIZE);
+            init_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, print_update, MEM_POOL_SIZE);
             if (init_state === undefined) return;
         } else {
             init_state = appState.C0Runtime;
@@ -119,8 +116,7 @@ export default function MainControlBar(props: MainControlProps) {
 
     const restart_c0runtime = async () => {
         clear_print();
-        const typedefs = extract_all_typedef(appState.C0Editors);
-        const new_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, typedefs, print_update, globalThis.MEM_POOL_SIZE);
+        const new_state = await VM.initialize(appState.BC0SourceCode, clear_print, appState.C0Editors, print_update, globalThis.MEM_POOL_SIZE);
         props.set_app_state({C0Runtime: new_state});
     };
 
@@ -137,15 +133,14 @@ export default function MainControlBar(props: MainControlProps) {
             print_update,
         );
     };
+   
+    const compilebtn_disabled = appState.C0Editors[0].content === "";
+    const stepbtn_disabled    = (!is_bc0_valid) || appState.C0Running || appState.contentChanged;
+    const runbtn_disabled     = (!is_bc0_valid) || appState.C0Running || appState.contentChanged;
 
-    // const test_fn = () => {
-    //     // extract_typedef("typedef struct node node_t;\n typedef struct ll_head ll_head_t;\n int main() { return 0; }");
-    // }
-
-    // UI Buttons
     const CompileButton = 
         <button
-            className={"base-btn main-btn unselectable " + (appState.C0Editors[0].content === "" ? "disable-btn" : "")}
+            className={"base-btn main-btn unselectable " + (compilebtn_disabled ? "disable-btn" : "")}
             onClick={compile_c0source}
         >
             <FontAwesomeIcon icon={faScrewdriverWrench} className="hide-in-mobile"/> {" Compile "}
@@ -153,7 +148,7 @@ export default function MainControlBar(props: MainControlProps) {
     
     const StepButton = 
         <button
-            className={"base-btn success-btn unselectable " + (is_bc0_valid && !appState.C0Running ? "" : "disable-btn")}
+            className={"base-btn success-btn unselectable " + (stepbtn_disabled ? "disable-btn" : "")}
             onClick={step_c0runtime}
         >
             <FontAwesomeIcon icon={faStepForward} className="hide-in-mobile"/>{" Step "}
@@ -161,7 +156,7 @@ export default function MainControlBar(props: MainControlProps) {
     
     const RunButton = 
         <button
-            className={"base-btn success-btn unselectable " + (is_bc0_valid && !appState.C0Running ? "" : "disable-btn")}
+            className={"base-btn success-btn unselectable " + (runbtn_disabled ? "disable-btn" : "")}
             onClick={run_c0runtime}
         >
             <FontAwesomeIcon icon={faPlay} className="hide-in-mobile"/>{" Run "}
@@ -183,15 +178,6 @@ export default function MainControlBar(props: MainControlProps) {
         >
             <FontAwesomeIcon icon={faUndo} className="hide-in-mobile"/>{" Restart "}
         </button>;
-    
-    // const DevTestButton = 
-    //     <button
-    //         className="base-btn danger-btn unselectable"
-    //         id="ctr-btn-restart"
-    //         onClick={test_fn}
-    //     >
-    //         <FontAwesomeIcon icon={faCode} className="hide-in-mobile"/>{" Dev Test "}
-    //     </button>;
 
     return (
         <div className="main-control">

--- a/src/components/main-footer.tsx
+++ b/src/components/main-footer.tsx
@@ -1,11 +1,11 @@
 import { faCheck, faFileLines, faGear, faSpinner, faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
-import C0VM_RuntimeState from "../vm_core/exec/state";
+
 
 export default class C0VMApplicationFooter extends React.PureComponent<{state: C0VMApplicationState, open_setting: () => void}> {
     render() {
-        const s = this.props.state.C0Runtime as (C0VM_RuntimeState | undefined);
+        const s = this.props.state.C0Runtime;
         let vm_indicator;
         if (s === undefined) {
             vm_indicator = <p><FontAwesomeIcon icon={faXmark}/> Not Loaded</p>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@ import AppCrashFallbackPage from './components/app_crash_fallback';
 // Global Variables
 global.C0VM_VERSION = "0.3.1-Beta";
 
-globalThis.DEBUG = false;
+globalThis.DEBUG = true;
 globalThis.DEBUG_DUMP_MEM = false;
 globalThis.DEBUG_DUMP_STEP = false;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ import AntdEmitter from './utility/antd_emitter';
 import AppCrashFallbackPage from './components/app_crash_fallback';
 
 // Global Variables
-global.C0VM_VERSION = "0.3.1-Beta";
+global.C0VM_VERSION = "0.3.2-Beta";
 
 globalThis.DEBUG = true;
 globalThis.DEBUG_DUMP_MEM = false;

--- a/src/network/c0_parser.ts
+++ b/src/network/c0_parser.ts
@@ -1,4 +1,30 @@
 import { C0Language } from "../components/editor_extension/syntax/c0";
+import { String2Type } from "../utility/c0_type_utility";
+
+
+function extract_library(code: string) {
+    const syntaxTree = C0Language.parser.parse(code);
+    const libraries = [];
+
+    for (let ptr = syntaxTree.cursor(); ptr.next() !== false; ){
+        if (ptr.type.is("LibraryImport")){
+            ptr.firstChild();
+            ptr.nextSibling();
+            const library_name = code.substring(ptr.from, ptr.to);
+            libraries.push(library_name)
+        }
+    }
+    return libraries;
+}
+
+function extract_all_libraries(editors: C0EditorTab[]): Set<string>{
+    const libraries = [];
+    for (const editor of editors){
+        libraries.push(...extract_library(editor.content));
+    }
+    return new Set(libraries);
+}
+
 
 /**
  * Given a C0 code string, return a list of Typedefs defined in the given code string
@@ -50,12 +76,149 @@ function flatten_typedef(typedefs: TypeDefInfo[]): Map<string, string> {
     return flattened;
 }
 
+function next_real_sibling(ptr: any){
+    let result = ptr.nextSibling();
+    while (ptr.type.is("Comment") || ptr.type.is("CommentBlock")) {
+        result = ptr.nextSibling();
+    }
+    return result
+}
+
+function extract_struct(code: string): Map<string, Struct_Type_Record[]> {
+    const syntaxTree = C0Language.parser.parse(code);
+
+    const structInfos: Map<string, Struct_Type_Record[]> = new Map();
+
+    for (let ptr = syntaxTree.cursor(); ptr.next() !== false; ){
+        if (ptr.type.is("StructDefinition")){
+            ptr.firstChild();
+            const structureType = code.substring(ptr.from, ptr.to);
+            const fieldTypes: Struct_Type_Record[] = [];
+
+            next_real_sibling(ptr);  // ptr is now StructScope
+            ptr.firstChild();   // Moving into StructScope
+
+            while (next_real_sibling(ptr) && ptr.type.is("Type")){
+                const fieldType = String2Type(code.substring(ptr.from, ptr.to));
+                next_real_sibling(ptr);
+                const fieldName = code.substring(ptr.from, ptr.to);
+                next_real_sibling(ptr);
+                fieldTypes.push({type: fieldType, name: fieldName});
+            }
+            structInfos.set(structureType, fieldTypes);
+        }
+    }
+    return structInfos;
+}
 
 
+function extract_all_structs(editors: C0EditorTab[]): Map<string, Struct_Type_Record[]>{
+    let all_structs: Map<string, Struct_Type_Record[]> = new Map();
+    for (const editor of editors){
+        const new_structs = extract_struct(editor.content);
+        all_structs = new Map([...Array.from(all_structs), ...Array.from(new_structs)]);
+    }
+    return all_structs;
+}
+
+export function extract_all_structType(editors: C0EditorTab[]){
+    const structInformation = extract_all_structs(editors);
+    const typeAlias         = extract_all_typedef(editors);
+    const structTypeRecords = new Map<string, Map<number, Struct_Type_Record>>();
+    
+    for (let [structName, structFields] of Array.from(structInformation)){
+        let structTypeRecord = new Map<number, Struct_Type_Record>();
+        let offset = 0;
+        let continueParsingFlag = true;
+
+        for (const structField of structFields){
+            if (!continueParsingFlag) break;
+
+            if (structField.type === undefined) {
+                continueParsingFlag = false;
+                break;
+            }
+            
+            // Some manually crafted memory alignment rules...
+            switch (structField.type.type) {
+                case "ptr": 
+                case "string":
+                    offset = Math.ceil(offset / 8) * 8;
+                    break;
+                case "value":
+                    if (structField.type.value === "int"){
+                        offset = Math.ceil(offset / 4) * 4;
+                    } else {
+                        offset = offset + 0;    // (No memory alignment rule for char and bool)
+                    }
+                    break;
+                case "<unknown>":
+                    continueParsingFlag = false;
+                    break;
+            }
+
+            structTypeRecord.set(offset, structField);
+
+            switch (structField.type.type) {
+                case "ptr":
+                case "string":
+                    offset += 8;
+                    break;
+                case "value":
+                    if (structField.type.value === "int") {
+                        offset += 4;
+                    } else {
+                        offset += 1;
+                    }
+                    break;
+                case "<unknown>":
+                    continueParsingFlag = false;
+                    break;
+            }
+        }
+
+        if (!continueParsingFlag) { 
+            if (DEBUG) {console.warn(`Failed to extract type information for ${structName}`);}
+            continue;
+        }
+
+        let recordName = structName;
+        if (typeAlias.has(structName)){
+            recordName = typeAlias.get(structName) as string;
+        }
+        structTypeRecords.set(recordName, structTypeRecord);
+    }
+    return structTypeRecords;
+}
+
+// Extract all typedefs in current editor
+// in format of {source: alias}
 export function extract_all_typedef(editors: C0EditorTab[]): Map<string, string>{
     const rawTypedefs = [];
     for (const editor of editors) {
         rawTypedefs.push(...extract_typedef(editor.content));
     }
-    return flatten_typedef(rawTypedefs);
+    const typedef = flatten_typedef(rawTypedefs);
+    const revTypedef = new Map<string, string>();
+    typedef.forEach((source, alias) => {revTypedef.set(source, alias)});
+
+    return revTypedef;
 }
+
+// Check if all libraries used in program is supported by C0VM.ts
+// reject if contains
+//
+// args - argument from CLI
+// img  - image interface
+// file - file I/O
+// curses - interaction on stdout
+export function is_all_library_supported(editors: C0EditorTab[]){
+    const libraries = extract_all_libraries(editors);
+    return !(
+        libraries.has("args")  ||
+        libraries.has("img")   ||
+        libraries.has("file")  ||
+        libraries.has("curses")
+    );
+}
+

--- a/src/network/c0_parser.ts
+++ b/src/network/c0_parser.ts
@@ -1,0 +1,17 @@
+import { C0Language } from "../components/editor_extension/syntax/c0";
+
+
+export function extract_typedef(code: string){
+    const syntaxTree = C0Language.parser.parse(code);
+
+    for (let ptr = syntaxTree.cursor(); ptr.next() !== false; ){
+        if (ptr.type.is("TypeDefinition")){
+            ptr.firstChild();       // ptr = typedef keyword itself
+            ptr.nextSibling();      // ptr = Source Type
+            const source_type = code.substring(ptr.from, ptr.to);
+            ptr.nextSibling();      // ptr = Target Type
+            const alias_type = code.substring(ptr.from, ptr.to);
+            console.log(source_type, " |> ", alias_type);
+        }
+    }
+}

--- a/src/network/c0_parser.ts
+++ b/src/network/c0_parser.ts
@@ -1,8 +1,13 @@
 import { C0Language } from "../components/editor_extension/syntax/c0";
 
-
-export function extract_typedef(code: string){
+/**
+ * Given a C0 code string, return a list of Typedefs defined in the given code string
+ * @param code C0 code
+ * @returns a list of typedefs in format {source: T, alais: T'}
+ */
+function extract_typedef(code: string): TypeDefInfo[] {
     const syntaxTree = C0Language.parser.parse(code);
+    const typedefs: TypeDefInfo[] = [];
 
     for (let ptr = syntaxTree.cursor(); ptr.next() !== false; ){
         if (ptr.type.is("TypeDefinition")){
@@ -11,7 +16,46 @@ export function extract_typedef(code: string){
             const source_type = code.substring(ptr.from, ptr.to);
             ptr.nextSibling();      // ptr = Target Type
             const alias_type = code.substring(ptr.from, ptr.to);
-            console.log(source_type, " |> ", alias_type);
+            
+            typedefs.push({ source: source_type, alias: alias_type });
         }
     }
+
+    return typedefs
+}
+
+/**
+ * Resolve the nested reference in map automatically
+ * 
+ * e.g. A -> B, D -> B, B -> C
+ * will be flattened to:
+ * A -> C, B -> C, D -> C
+ * 
+ * @returns A flattened type mapping
+ */
+function flatten_typedef(typedefs: TypeDefInfo[]): Map<string, string> {
+    const original_map = new Map<string, string>(); // alias -> source
+    for (const typedef of typedefs){
+        original_map.set(typedef.alias, typedef.source);
+    }
+    const flattened = new Map<string, string>();
+    original_map.forEach(
+        (source, alias) => {
+            let actual_source = source;
+            while (original_map.has(actual_source)) {
+                actual_source = original_map.get(actual_source) as string;
+            }
+            flattened.set(alias, actual_source);
+        })
+    return flattened;
+}
+
+
+
+export function extract_all_typedef(editors: C0EditorTab[]): Map<string, string>{
+    const rawTypedefs = [];
+    for (const editor of editors) {
+        rawTypedefs.push(...extract_typedef(editor.content));
+    }
+    return flatten_typedef(rawTypedefs);
 }

--- a/src/network/remote_compile.ts
+++ b/src/network/remote_compile.ts
@@ -1,6 +1,6 @@
 import { vm_error } from "../utility/errors";
 import * as VM from "../vm_core/vm_interface"; 
-import { extract_all_typedef } from "./c0_parser";
+import { is_all_library_supported } from "./c0_parser";
 
 export default function remote_compile(
     app_state: C0VMApplicationState,
@@ -8,6 +8,14 @@ export default function remote_compile(
     clean_printout: () => void,
     print_update: (s: string) => void,
 ): void {
+    if (!is_all_library_supported(app_state.C0Editors)){
+        globalThis.MSG_EMITTER.warn(
+            "Unsupported Library Used", 
+            "The C0 visualizer does not support 'file', 'img', 'args', and 'cursor' libraries, please remove these dependencies."
+        );
+        return;
+    }
+
     fetch(globalThis.COMPILER_BACKEND_URL + `?dyn_check=${app_state.CompilerFlags["-d"] ? "true" : "false"}`, {
         method: "POST",
         cache: "no-cache",
@@ -16,7 +24,7 @@ export default function remote_compile(
             "Access-Control-Allow-Origin": "*",
         },
         body: JSON.stringify({
-            codes: app_state.C0Editors.map((tab) => tab.content),
+            codes    : app_state.C0Editors.map((tab) => tab.content),
             filenames: app_state.C0Editors.map((tab) => tab.title),
         })
     })
@@ -30,9 +38,8 @@ export default function remote_compile(
                 throw new vm_error("Compile Failed for c0 source code. See standard output for more information.");
             }
             
-            const typedefs = extract_all_typedef(app_state.C0Editors);
             set_app_state({BC0SourceCode: result.bytecode});
-            return VM.initialize(result.bytecode, clean_printout, app_state.C0Editors, typedefs, print_update, MEM_POOL_SIZE);
+            return VM.initialize(result.bytecode, clean_printout, app_state.C0Editors, print_update, MEM_POOL_SIZE);
         }
     )
     .then(

--- a/src/network/remote_compile.ts
+++ b/src/network/remote_compile.ts
@@ -1,5 +1,6 @@
 import { vm_error } from "../utility/errors";
 import * as VM from "../vm_core/vm_interface"; 
+import { extract_all_typedef } from "./c0_parser";
 
 export default function remote_compile(
     app_state: C0VMApplicationState,
@@ -28,8 +29,10 @@ export default function remote_compile(
                 print_update(`<span class="error-output">${result.error as string}</span>`);
                 throw new vm_error("Compile Failed for c0 source code. See standard output for more information.");
             }
+            
+            const typedefs = extract_all_typedef(app_state.C0Editors);
             set_app_state({BC0SourceCode: result.bytecode});
-            return VM.initialize(result.bytecode, clean_printout, app_state.C0Editors, app_state.TypedefRecord, print_update, MEM_POOL_SIZE);
+            return VM.initialize(result.bytecode, clean_printout, app_state.C0Editors, typedefs, print_update, MEM_POOL_SIZE);
         }
     )
     .then(

--- a/src/types/react-interface.d.ts
+++ b/src/types/react-interface.d.ts
@@ -13,6 +13,7 @@ type BreakPoint = {
 /* Typedef statements in C0 source code */
 type TypeDefInfo = {
     source: string, /* source: the original type being aliased */
+    // alias: string,  /* alias: the alias type name in source code */
     key: number     /* key: the key of editor where this typedef info entry comes from */
 }
 
@@ -22,7 +23,6 @@ type C0EditorTab = {
     key    : number,            /* Key of editor tab */
     content: string,            /* Content (raw string) of that tab */
     breakpoints: BreakPoint[]   /* Breakpoints attatched to that tab */
-    innerRef: React.Ref<ReactCodeMirrorRef>
 };
 
 interface C0VMApplicationState {
@@ -42,7 +42,7 @@ interface C0VMApplicationState {
     PrintoutValue  : string,          /* The string to show in the stdout console */
 
     C0Running      : boolean,         /* If the C0VM is running currently */
-    C0Runtime      : C0VM_RuntimeState | undefined,   /* Runtime of C0VM */
+    C0Runtime      : C0VM_RT | undefined,   /* Runtime of C0VM */
     CompilerFlags  : Record<string, boolean>          /* Compiler Flags (-d) */
 };
 
@@ -104,7 +104,6 @@ interface C0EditorProps {
     editorValue   : string,                     /* Editor content (raw string) */
     editable      : boolean                     /* Is editor editable? (if false, in read-only mode) */
     breakPoints   : BreakPoint[],               /* Breakpoints attatched to this editor */
-    innerRef      : React.Ref<ReactCodeMirrorRef>,
     
     updateContent : (s: string) => void,
     updateTypedef : (newTypeDef: Map<string, string>) => void,
@@ -131,7 +130,7 @@ interface C0OutputPropInterface {
 };
 
 interface DebugConsoleProps {
-    state: C0VM_RuntimeState | undefined,
+    state: C0VM_RT | undefined,
     c0_only: boolean,
     isFullScreen: boolean,
     typedef: Map<string, TypeDefInfo>,

--- a/src/types/react-interface.d.ts
+++ b/src/types/react-interface.d.ts
@@ -13,8 +13,8 @@ type BreakPoint = {
 /* Typedef statements in C0 source code */
 type TypeDefInfo = {
     source: string, /* source: the original type being aliased */
-    // alias: string,  /* alias: the alias type name in source code */
-    key: number     /* key: the key of editor where this typedef info entry comes from */
+    alias: string,  /* alias: the alias type name in source code */
+    // key: number     /* key: the key of editor where this typedef info entry comes from */
 }
 
 /* Describes a C0Editor Tab */
@@ -35,7 +35,6 @@ interface C0VMApplicationState {
     BC0SourceCode  : string,          /* The content of BC0 code editor */
     BC0BreakPoints : Set<BreakPoint>, /* Breakpoints activated in BC0 code editor */
 
-    TypedefRecord  : Map<string, TypeDefInfo>, /* Record the typedef names for string substitution */
     C0Editors      : C0EditorTab[],   /* Code editor tab titles */
     ActiveEditor   : number,          /* Currently activated tab index of C0Editor */
 
@@ -95,7 +94,6 @@ interface C0EditorGroupProps {
     removePanel  : (key: string) => void,
 
     updateContent: (key: number, s: string) => void,
-    updateTypedef: (key: number, newTypeDef: Map<string, string>) => void;
 }
 
 
@@ -106,7 +104,6 @@ interface C0EditorProps {
     breakPoints   : BreakPoint[],               /* Breakpoints attatched to this editor */
     
     updateContent : (s: string) => void,
-    updateTypedef : (newTypeDef: Map<string, string>) => void,
     setBreakPts   : (lns: BreakPoint[]) => void,
     updateName    : (s: string) => void,
 }
@@ -133,7 +130,6 @@ interface DebugConsoleProps {
     state: C0VM_RT | undefined,
     c0_only: boolean,
     isFullScreen: boolean,
-    typedef: Map<string, TypeDefInfo>,
     setFullScreen: (s: boolean) => void
 }
 
@@ -148,22 +144,22 @@ interface DebugConsoleInterface {
     state: VM_State
     mem: C0HeapAllocator
     cnt: number
-    typedef: Map<string, TypeDefInfo>
+    typedef: Map<string, string>
 }
 
 interface TabularStackFrameProps {
     frame: VM_StackFrame,
     mem: C0HeapAllocator,
     typeRecord: Map<string, Map<number, Struct_Type_Record>>,
-    typedefRec: Map<string, TypeDefInfo>
+    typedef: Map<string, string>
 }
 
 
 interface C0ValueTabularDisplayProps {
     mem: C0HeapAllocator,
     value: C0Value<C0TypeClass>,
+    typedef: Map<string, string>,
     typeRecord: Map<string, Map<number, Struct_Type_Record>>,
-    typedefRec: Map<string, TypeDefInfo>,
     default_expand: boolean
 }
 

--- a/src/types/react-interface.d.ts
+++ b/src/types/react-interface.d.ts
@@ -22,6 +22,7 @@ type C0EditorTab = {
     key    : number,            /* Key of editor tab */
     content: string,            /* Content (raw string) of that tab */
     breakpoints: BreakPoint[]   /* Breakpoints attatched to that tab */
+    innerRef: React.Ref<ReactCodeMirrorRef>
 };
 
 interface C0VMApplicationState {
@@ -103,6 +104,7 @@ interface C0EditorProps {
     editorValue   : string,                     /* Editor content (raw string) */
     editable      : boolean                     /* Is editor editable? (if false, in read-only mode) */
     breakPoints   : BreakPoint[],               /* Breakpoints attatched to this editor */
+    innerRef      : React.Ref<ReactCodeMirrorRef>,
     
     updateContent : (s: string) => void,
     updateTypedef : (newTypeDef: Map<string, string>) => void,

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -268,9 +268,10 @@ declare abstract class C0VM_RT {
     public state    : VM_State;
     public allocator: C0HeapAllocator;
     public heap_size: number | undefined;
-    public step_cnt: number;
+    public step_cnt : number;
+    public typedef  : Map<string, string>;
 
-    abstract constructor(bytecode: string, c0source: C0EditorTab[], typedef: Map<string, TypeDefInfo>, heapSize?: number, parsed_result?: C0ByteCode)
+    abstract constructor(bytecode: string, c0source: C0EditorTab[], typedef: Map<string, string>, heapSize?: number, parsed_result?: C0ByteCode)
     abstract async step_forward(UIHooks: ReactUIHook): Promise<boolean>;
     abstract clone(): C0VM_RT
     abstract debug(): any;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -263,7 +263,16 @@ type VM_State = {
 
 
 declare abstract class C0VM_RT {
+    public raw_code : string;
+    public code     : C0ByteCode;
+    public state    : VM_State;
+    public allocator: C0HeapAllocator;
+    public heap_size: number | undefined;
+    public step_cnt: number;
+
+    abstract constructor(bytecode: string, c0source: C0EditorTab[], typedef: Map<string, TypeDefInfo>, heapSize?: number, parsed_result?: C0ByteCode)
     abstract async step_forward(UIHooks: ReactUIHook): Promise<boolean>;
+    abstract clone(): C0VM_RT
     abstract debug(): any;
 }
 

--- a/src/utility/c0_type_utility.ts
+++ b/src/utility/c0_type_utility.ts
@@ -38,33 +38,32 @@ export function CloneType(T: C0Type<C0TypeClass>): C0Type<C0TypeClass> {
  * @param T The type to be converted to the string
  * @returns The C0 type name (e.g. `int*`)
  */
-export function Type2String(T: C0Type<C0TypeClass> | string, TypedefRec?: Map<string, TypeDefInfo>): string {
-    if (typeof T === "string") return T;
-    
-    switch (T.type) {
-        case "ptr":
-            if (T.kind === "arr") return Type2String(T.value, TypedefRec) + "[]";
-            else if (T.kind === "ptr") return Type2String(T.value, TypedefRec) + "*";
-            else if (T.kind === "struct") {
-                if (TypedefRec === undefined) return T.value;
+export function Type2String(T: C0Type<C0TypeClass> | string, TypedefRec?: Map<string, string>): string {
+    let retVal = "";
 
-                // Wrap to typedef'd version if possible
-                for (let entry of Array.from(TypedefRec.entries())) {
-                    const key = entry[0];
-                    const value = entry[1];
-                    if (value.source === T.value) return key
-                }
-
-                return T.value;
-            }
-            else return "";
-        case "string":
-            return "string";
-        case "<unknown>":
-            return "<unknown>";
-        case "value":
-            return T.value;
+    if (typeof T === "string") retVal = T;
+    else {
+        switch (T.type) {
+            case "ptr":
+                if (T.kind === "arr") retVal = Type2String(T.value, TypedefRec) + "[]";
+                else if (T.kind === "ptr") retVal = Type2String(T.value, TypedefRec) + "*";
+                else if (T.kind === "struct") retVal = T.value
+                else retVal = "";
+                break;
+            case "string":
+                retVal = "string";
+                break;
+            case "<unknown>":
+                retVal = "<unknown>";
+                break;
+            case "value":
+                retVal = T.value;
+                break;
+        }
     }
+    if (TypedefRec === undefined) return retVal;
+    if (TypedefRec.has(retVal)) return TypedefRec.get(retVal) as string;
+    return retVal;
 }
 
 /**

--- a/src/vm_core/exec/state.ts
+++ b/src/vm_core/exec/state.ts
@@ -13,6 +13,7 @@ export default class C0VM_RuntimeState implements C0VM_RT{
     public allocator: C0HeapAllocator;
     public heap_size: undefined | number
     public step_cnt: number
+    public typedef: Map<string, string>;
 
     /**
      * Creating a new C0VM Runtime
@@ -20,8 +21,9 @@ export default class C0VM_RuntimeState implements C0VM_RT{
      * @param heapSize Heap size (in bytes), optional, if not explicitly designated, then use the 
      * GlobalThis.MEM_POOL_DEFAULT_SIZE as the size.
      */
-    constructor(rawByteCode: string, C0Source: C0EditorTab[], TypedefRecord: Map<string, TypeDefInfo>, heapSize?: number, parsed_result?: C0ByteCode) {
+    constructor(rawByteCode: string, C0Source: C0EditorTab[], TypedefRecord: Map<string, string>, heapSize?: number, parsed_result?: C0ByteCode) {
         this.raw_code = rawByteCode;
+        this.typedef = TypedefRecord;
         this.code = parsed_result === undefined ? parse(rawByteCode, C0Source, TypedefRecord) : parsed_result;
         this.heap_size = heapSize;
         this.allocator = createHeap(VM_Memory, heapSize);
@@ -62,7 +64,7 @@ export default class C0VM_RuntimeState implements C0VM_RT{
      * @returns a clone of current runtime state
      */
     public clone(): C0VM_RT {
-        const C = new C0VM_RuntimeState(this.raw_code, [], new Map(), this.heap_size, this.code);
+        const C = new C0VM_RuntimeState(this.raw_code, [], this.typedef, this.heap_size, this.code);
         
         C.state = this.state;
         C.allocator = this.allocator;

--- a/src/vm_core/exec/state.ts
+++ b/src/vm_core/exec/state.ts
@@ -26,7 +26,9 @@ export default class C0VM_RuntimeState implements C0VM_RT{
         this.heap_size = heapSize;
         this.allocator = createHeap(VM_Memory, heapSize);
         this.step_cnt = 0;
+        
         const str_ptr = loadStringPool(this.code.stringPool, this.allocator);
+        
         this.state = {
             P: this.code,
             C: {
@@ -59,7 +61,7 @@ export default class C0VM_RuntimeState implements C0VM_RT{
      * to be immutable
      * @returns a clone of current runtime state
      */
-    public clone(): C0VM_RuntimeState {
+    public clone(): C0VM_RT {
         const C = new C0VM_RuntimeState(this.raw_code, [], new Map(), this.heap_size, this.code);
         
         C.state = this.state;

--- a/src/vm_core/exec/state.ts
+++ b/src/vm_core/exec/state.ts
@@ -2,11 +2,13 @@ import { step } from "./exec";
 import { createHeap, VM_Memory } from "../utility/memory";
 import parse from "../parser/parse";
 import { loadStringPool } from "../../utility/string_utility";
+import { extract_all_structType, extract_all_typedef } from "../../network/c0_parser";
 
 /**
  * The C0 Virtual Machine Runtime with interface of operation
  */
 export default class C0VM_RuntimeState implements C0VM_RT{
+    public c0_source: C0EditorTab[];
     public raw_code: string;
     public code: C0ByteCode;
     public state: VM_State;
@@ -21,13 +23,14 @@ export default class C0VM_RuntimeState implements C0VM_RT{
      * @param heapSize Heap size (in bytes), optional, if not explicitly designated, then use the 
      * GlobalThis.MEM_POOL_DEFAULT_SIZE as the size.
      */
-    constructor(rawByteCode: string, C0Source: C0EditorTab[], TypedefRecord: Map<string, string>, heapSize?: number, parsed_result?: C0ByteCode) {
-        this.raw_code = rawByteCode;
-        this.typedef = TypedefRecord;
-        this.code = parsed_result === undefined ? parse(rawByteCode, C0Source, TypedefRecord) : parsed_result;
+    constructor(rawByteCode: string, C0Source: C0EditorTab[], heapSize?: number) {
+        this.c0_source = C0Source;
+        this.raw_code  = rawByteCode;
+        this.typedef   = extract_all_typedef(this.c0_source);
+        this.code      = parse(rawByteCode, C0Source, this.typedef);
         this.heap_size = heapSize;
         this.allocator = createHeap(VM_Memory, heapSize);
-        this.step_cnt = 0;
+        this.step_cnt  = 0;
         
         const str_ptr = loadStringPool(this.code.stringPool, this.allocator);
         
@@ -45,7 +48,7 @@ export default class C0VM_RuntimeState implements C0VM_RT{
             },
             CurrLineNumber: 0,
             CurrC0RefLine: undefined,
-            TypeRecord: new Map<string, Map<number, Struct_Type_Record>>(),
+            TypeRecord: extract_all_structType(C0Source),
         };
     }
 
@@ -64,7 +67,7 @@ export default class C0VM_RuntimeState implements C0VM_RT{
      * @returns a clone of current runtime state
      */
     public clone(): C0VM_RT {
-        const C = new C0VM_RuntimeState(this.raw_code, [], this.typedef, this.heap_size, this.code);
+        const C = new C0VM_RuntimeState(this.raw_code, this.c0_source, this.heap_size);
         
         C.state = this.state;
         C.allocator = this.allocator;

--- a/src/vm_core/parser/parse.ts
+++ b/src/vm_core/parser/parse.ts
@@ -22,8 +22,7 @@ import { nativeFuncLoader } from "../native/native_interface";
  * @param typedefRecord Typedef information extracted from c0 editors
  * @returns A parsed bytecode data structure.
  */
-export default function parse(bytecode: string, C0Editors: C0EditorTab[], typedefRecord: Map<string, TypeDefInfo>): C0ByteCode {
-    const typedef_lib = typedefRecord === undefined ? undefined : flatten_typedef(typedefRecord);
+export default function parse(bytecode: string, C0Editors: C0EditorTab[], typedef_lib: Map<string, string>): C0ByteCode {
     const lines = annotate_linenum(bytecode);   // Add line number info to each line
     const blocks = split_blocks(lines);
 
@@ -67,7 +66,6 @@ export default function parse(bytecode: string, C0Editors: C0EditorTab[], typede
     // Load Native function here
     [parsing.nativeCount, parsing.nativePool] = parse_native_block(blocks[blocks.length - 1]);
 
-    if (DEBUG) console.log(parsing);
     return parsing;
 }
 
@@ -92,29 +90,6 @@ function safe_parse_hex(s: string): number {
 
 function safe_combine_and_parse_hex(s: string): number {
     return safe_parse_hex(s.replaceAll(" ", ""));
-}
-
-/**
- * Resolve the nested reference in map automatically
- * 
- * e.g. A -> B, D -> B, B -> C
- * will be flattened to:
- * A -> C, B -> C, D -> C
- * 
- * @returns A flattened type mapping
- */
- function flatten_typedef(typedef: Map<string, TypeDefInfo>): Map<string, string> {
-    const flattened = new Map<string, string>();
-    typedef.forEach(
-        (value, key) => {
-            let base_case = value.source;
-            while (typedef.has(base_case)) {
-                base_case = (typedef.get(base_case) as TypeDefInfo).source;
-            }
-            flattened.set(key, base_case);
-        }
-    )
-    return flattened;
 }
 
 function annotate_linenum(bytecode: string): [string, number][] {

--- a/src/vm_core/vm_interface.ts
+++ b/src/vm_core/vm_interface.ts
@@ -1,15 +1,16 @@
 import C0VM_RuntimeState from "./exec/state";
 
-export async function initialize(s: string, clear_printout: () => void,
+export async function initialize(
+    bytecode: string,
+    clear_printout: () => void,
     C0Editor : C0EditorTab[],
-    TypedefRecord : Map<string, string>,
     print_update: (s: string) => void,
     heapSize ?: number,
 ): Promise<C0VM_RT | undefined> {
     // Clean up environment before initialize.
     clear_printout();
     try {
-        const ns = new C0VM_RuntimeState(s, C0Editor, TypedefRecord, heapSize, undefined);
+        const ns = new C0VM_RuntimeState(bytecode, C0Editor, heapSize);
         globalThis.MSG_EMITTER.ok("Load Successfully", "Program is loaded successfully. Press step or run to see result.");
         if (globalThis.DEBUG_DUMP_MEM) {
             console.log(ns.allocator.debug_getMemPool());
@@ -19,6 +20,7 @@ export async function initialize(s: string, clear_printout: () => void,
             console.log({
                 "Parsed Result": ns.code,
                 "Typedef": ns.typedef,
+                "Struct Information": ns.state.TypeRecord,
             });
         }
 

--- a/src/vm_core/vm_interface.ts
+++ b/src/vm_core/vm_interface.ts
@@ -2,7 +2,7 @@ import C0VM_RuntimeState from "./exec/state";
 
 export async function initialize(s: string, clear_printout: () => void,
     C0Editor : C0EditorTab[],
-    TypedefRecord : Map<string, TypeDefInfo>,
+    TypedefRecord : Map<string, string>,
     print_update: (s: string) => void,
     heapSize ?: number,
 ): Promise<C0VM_RT | undefined> {
@@ -14,6 +14,14 @@ export async function initialize(s: string, clear_printout: () => void,
         if (globalThis.DEBUG_DUMP_MEM) {
             console.log(ns.allocator.debug_getMemPool());
         }
+
+        if (globalThis.DEBUG){
+            console.log({
+                "Parsed Result": ns.code,
+                "Typedef": ns.typedef,
+            });
+        }
+
         return ns;
     } catch (e) {
         const err = e as Error;

--- a/src/vm_core/vm_interface.ts
+++ b/src/vm_core/vm_interface.ts
@@ -5,7 +5,7 @@ export async function initialize(s: string, clear_printout: () => void,
     TypedefRecord : Map<string, TypeDefInfo>,
     print_update: (s: string) => void,
     heapSize ?: number,
-): Promise<C0VM_RuntimeState | undefined> {
+): Promise<C0VM_RT | undefined> {
     // Clean up environment before initialize.
     clear_printout();
     try {
@@ -24,7 +24,7 @@ export async function initialize(s: string, clear_printout: () => void,
     }
 }
 
-export async function step(s: C0VM_RuntimeState, c0_only: boolean, print_update: (s: string) => void): Promise<[C0VM_RuntimeState, boolean]> {
+export async function step(s: C0VM_RT, c0_only: boolean, print_update: (s: string) => void): Promise<[C0VM_RT, boolean]> {
     const new_state = s.clone();
     if (c0_only && new_state.state.CurrC0RefLine !== undefined) {
         /**
@@ -60,14 +60,14 @@ export async function step(s: C0VM_RuntimeState, c0_only: boolean, print_update:
 }
 
 export async function run(
-    s: C0VM_RuntimeState,
+    s: C0VM_RT,
     bp: Set<number>,
     c0bp: Set<string>,
     signal: {abort: boolean},
     resetSig: () => void,
     print_update: (s: string) => void,
-    update_state: (s: C0VM_RuntimeState) => void,
-): Promise<[C0VM_RuntimeState, boolean]> {
+    update_state: (s: C0VM_RT) => void,
+): Promise<[C0VM_RT, boolean]> {
     const new_state = s.clone();
     let can_continue = true;
     while (can_continue) {


### PR DESCRIPTION
Fix issue #9 by scanning the C0 source code at every execution and do following things:
1. Extract all field names and types
2. For each detected struct definition, calculate the offset of each field using hand-written memory alignment rules
3. Pass the inferenced type information into C0Runtime by setting `state.TypeRecord` field manually.

Other major changes:
1. Cleanup the app state, remove `typedefs` state in application as we can now parse the source code after code is compiled.